### PR TITLE
net loopback fix

### DIFF
--- a/src/CoopConfig.ts
+++ b/src/CoopConfig.ts
@@ -6,7 +6,7 @@ export class CoopConfig {
     public protocol: string;
     public externalIP: string;
     public webSocketPort: number;
-    public useExternalIPFinder: boolean;
+    //public useExternalIPFinder: boolean;
     public webSocketTimeoutSeconds: number;
     public webSocketTimeoutCheckStartSeconds: number;
     public static Instance: CoopConfig;
@@ -15,7 +15,7 @@ export class CoopConfig {
         this.protocol = "http";
         this.externalIP = "127.0.0.1";
         this.webSocketPort = 6970;
-        this.useExternalIPFinder = true;
+        //this.useExternalIPFinder = true;
         this.webSocketTimeoutSeconds = 5;
         this.webSocketTimeoutCheckStartSeconds = 120;
 
@@ -28,16 +28,18 @@ export class CoopConfig {
         // console.log(coopConfigFilePath);
         if(!fs.existsSync(coopConfigFilePath)) {
             console.warn(`Coop Config doesn't exist, creating default config.`);
-            console.warn(`BE AWARE! ExternalIPFinder is ACTIVE! The externalIP config value is ignored!`);
+            //console.warn(`BE AWARE! ExternalIPFinder is ACTIVE! The externalIP config value is ignored!`);
             const coopcfgString = JSON.stringify(this, null, 4);
             fs.writeFileSync(coopConfigFilePath, coopcfgString);
         }
         else {
             Object.assign(this, JSON.parse(fs.readFileSync(coopConfigFilePath).toString()))
             console.log(`COOP MOD: Coop Config loaded.`);
+            /*
             if(this.useExternalIPFinder) {
                 console.log(`COOP MOD: BE AWARE! ExternalIPFinder is ACTIVE!`);
             }
+            */
         }
         // console.log(this);
 

--- a/src/WebSocketHandler.ts
+++ b/src/WebSocketHandler.ts
@@ -19,15 +19,6 @@ export class WebSocketHandler {
             const webSocketServer = new WebSocket.Server({
                 "port": webSocketPort,
                 perMessageDeflate: {
-                    zlibDeflateOptions: {
-                      // See zlib defaults.
-                      chunkSize: 1024,
-                      memLevel: 7,
-                      level: 3
-                    },
-                    zlibInflateOptions: {
-                      chunkSize: 10 * 1024
-                    },
                     // Other options settable:
                     clientNoContextTakeover: true, // Defaults to negotiated value.
                     serverNoContextTakeover: true, // Defaults to negotiated value.


### PR DESCRIPTION
this PR allows to use the IP for GameController provided by the launcher. the expected parameter in /launcher/profile/login object  is "backendUrl".

removed zlib on websocket for SIT, because we no longer use it.

added lost PR related to players already connected checks.