### PR TITLE
support all bundle file extension

### DIFF
--- a/src/StayInTarkovMod.ts
+++ b/src/StayInTarkovMod.ts
@@ -45,6 +45,7 @@ import { CoopMatchResponse } from "./CoopMatchResponse";
 import { friendlyAI } from "./FriendlyAI";
 import { SITCustomTraders } from "./Traders/SITCustomTraders";
 import { HttpServerHelper } from "@spt-aki/helpers/HttpServerHelper";
+import { BundleCallbacks } from "@spt-aki/callbacks/BundleCallbacks";
 // -------------------------------------------------------------------------
 
 
@@ -70,6 +71,7 @@ export class StayInTarkovMod implements IPreAkiLoadMod, IPostDBLoadMod
     resolvedExternalIP: string;
     profileHelper: ProfileHelper;
     httpServerHelper: HttpServerHelper;
+    bundleCallbacks: BundleCallbacks;
 
     public traders: any[] = [];
 
@@ -114,6 +116,7 @@ export class StayInTarkovMod implements IPreAkiLoadMod, IPostDBLoadMod
         this.bundleLoader = container.resolve<BundleLoader>("BundleLoader");
         this.profileHelper = container.resolve<ProfileHelper>("ProfileHelper");
         this.httpServerHelper = container.resolve<HttpServerHelper>("HttpServerHelper");
+        this.bundleCallbacks = container.resolve<BundleCallbacks>("BundleCallbacks");
 
         // this.traders.push(new SITCustomTraders(), new CoopGroupTrader(), new UsecTrader(), new BearTrader());
         this.traders.push(new SITCustomTraders());
@@ -199,6 +202,14 @@ export class StayInTarkovMod implements IPreAkiLoadMod, IPostDBLoadMod
 
                         output = JSON.stringify(friendlyAI);
                         return output;
+                    }
+                ),
+                new RouteAction(
+                    "/files/bundle",
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                    (url: string, info: any, sessionID: string, output: string): any =>
+                    {
+                        return this.bundleCallbacks.getBundle(url, info, sessionID);
                     }
                 )
             ]


### PR DESCRIPTION
This issue was brought up by SiulSC on Discord.

If bundle files have a different extension than .bundle, SPT will return an UNHANDLED exception and won't download the bundle correctly. However, custom bundle extensions are managed on normal standard SPT, so not sure why we're getting this issue with SITCoop. This PR aims to fix this issue.

Tested using this mod: https://hub.sp-tarkov.com/files/file/889-goblin-king/ which is using .goblin with some of its bundles. Confirmed to be working with this PR.