### PR TITLE
login password requirement + override refactoring

### DIFF
--- a/src/Overrides/BundleLoaderOverride.ts
+++ b/src/Overrides/BundleLoaderOverride.ts
@@ -21,21 +21,20 @@ class BundleInfo
     }
 }
 
-export class BundleLoaderFixed
+export class BundleLoaderOverride
 {
-    protected bundles: Record<string, BundleInfo> = {};
+    container: DependencyContainer;
     jsonUtil: JsonUtil;
     vfs: VFS;
-    backendUrl: string;
+    protected bundles: Record<string, BundleInfo> = {};
 
     constructor(
-        vfs: VFS,
-        jsonUtil: JsonUtil,
+        container: DependencyContainer
     )
     { 
-
-        this.vfs = vfs;
-        this.jsonUtil = jsonUtil;
+        this.container = container;
+        this.vfs = container.resolve<VFS>("VFS");
+        this.jsonUtil = container.resolve<JsonUtil>("JsonUtil");
     }
 
     public getBundles(local: boolean): BundleInfo[]
@@ -80,11 +79,11 @@ export class BundleLoaderFixed
         this.bundles[key] = b;
     }
 
-    public resolveAndOverride(container: DependencyContainer): void {
+    public override(): void {
 
         const thisObj = this;
 
-        container.afterResolution("BundleLoader", (_t, result: BundleLoader) => {
+        this.container.afterResolution("BundleLoader", (_t, result: BundleLoader) => {
             result.addBundle = (key: string, b: BundleInfo) => {
                 return thisObj.addBundle(key, b);
             }

--- a/src/Overrides/GameControllerOverride.ts
+++ b/src/Overrides/GameControllerOverride.ts
@@ -1,0 +1,76 @@
+import { DependencyContainer } from "tsyringe";
+import { GameController } from "@spt-aki/controllers/GameController";
+import { IGameConfigResponse } from "@spt-aki/models/eft/game/IGameConfigResponse";
+import { ProfileHelper } from "@spt-aki/helpers/ProfileHelper";
+import { DatabaseServer } from "@spt-aki/servers/DatabaseServer";
+
+export class GameControllerOverride
+{
+    container: DependencyContainer;
+
+    profileHelper: ProfileHelper;
+    databaseServer: DatabaseServer;
+    
+    protected sessionBackendUrl: Record<string, string> = {};
+    
+    constructor
+    (
+        container: DependencyContainer
+    )
+    {
+        this.container = container;
+        this.profileHelper = container.resolve<ProfileHelper>("ProfileHelper");
+        this.databaseServer = container.resolve<DatabaseServer>("DatabaseServer");
+    }
+
+    public setSessionBackendUrl(sessionID: string, backendUrl: string)
+    {
+        this.sessionBackendUrl[sessionID] = backendUrl;
+    }
+
+    private getGameConfig(sessionID: string, backendUrl: string): IGameConfigResponse
+    {
+        const profile = this.profileHelper.getPmcProfile(sessionID);
+
+        const config: IGameConfigResponse = {
+            languages: this.databaseServer.getTables().locales.languages,
+            ndaFree: false,
+            reportAvailable: false,
+            twitchEventMember: false,
+            lang: "en",
+            aid: profile.aid,
+            taxonomy: 6,
+            activeProfileId: `pmc${sessionID}`,
+            backend: {
+                Lobby: backendUrl,
+                Trading: backendUrl,
+                Messaging: backendUrl,
+                Main: backendUrl,
+                RagFair: backendUrl,
+            },
+            useProtobuf: false,
+            utc_time: new Date().getTime() / 1000,
+            totalInGame: profile.Stats?.Eft?.TotalInGameTime ?? 0
+        };
+
+        return config;
+    }
+
+    public override(): void 
+    {
+        this.container.afterResolution("GameController", (_t, result: GameController) => 
+        {
+            // We want to replace the original method logic with something different
+            result.getGameConfig = (sessionID: string) => 
+            {
+                // get the requestUrl for the sessionID
+                let backendUrl = this.sessionBackendUrl[sessionID];
+
+                delete this.sessionBackendUrl[sessionID];
+
+                return this.getGameConfig(sessionID, backendUrl);
+            }
+            // The modifier Always makes sure this replacement method is ALWAYS replaced
+        }, {frequency: "Always"});
+    }
+}

--- a/src/Overrides/LauncherControllerOverride.ts
+++ b/src/Overrides/LauncherControllerOverride.ts
@@ -1,0 +1,76 @@
+import { DependencyContainer } from "tsyringe";
+import { ILoginRequestData } from "@spt-aki/models/eft/launcher/ILoginRequestData";
+import { SaveServer } from "@spt-aki/servers/SaveServer";
+import { LauncherController } from "@spt-aki/controllers/LauncherController";
+import { CoopConfig } from "src/CoopConfig";
+import { GameControllerOverride } from "./GameControllerOverride";
+
+export class LauncherControllerOverride
+{
+    container: DependencyContainer;
+    saveServer: SaveServer;
+    gameControllerOverride: GameControllerOverride;
+    coopConfig: CoopConfig;
+    httpConfig: any;
+    
+    constructor
+    (
+        container: DependencyContainer,
+        gameControllerOverride: GameControllerOverride,
+        coopConfig: CoopConfig,
+        httpConfig: any
+    )
+    {
+        this.container = container;
+        this.saveServer = container.resolve<SaveServer>("SaveServer");
+        this.gameControllerOverride = gameControllerOverride;
+        this.coopConfig = coopConfig;
+        this.httpConfig = httpConfig;
+    }
+
+    private login(info: any)
+    {
+        for (const sessionID in this.saveServer.getProfiles())
+        {
+            const account = this.saveServer.getProfile(sessionID).info;
+            let backendUrl: string;
+            
+            if (info.username === account.username)
+            {
+                if(info.password === account.password)
+                {
+                    if(info.backendUrl !== undefined && info.backendUrl !== "")
+                    {
+                        backendUrl = info.backendUrl;
+                    }
+                    else
+                    {
+                        backendUrl = `${this.coopConfig.protocol}://${this.coopConfig.externalIP}:${this.httpConfig.port}`;
+                    }
+
+                    this.gameControllerOverride.setSessionBackendUrl(sessionID, backendUrl);
+                    
+                    return sessionID;
+                }
+                else
+                {
+                    return "INVALID_PASSWORD";
+                }
+            }
+        }
+
+        return "";
+    }
+
+    public override(): void
+    {
+        this.container.afterResolution("LauncherController", (_t, result: LauncherController) => {
+
+            // /launcher/profile/login
+            result.login = (info: any) =>
+            {
+                return this.login(info);
+            }
+        }, {frequency: "Always"});
+    }
+}

--- a/src/Overrides/LocationCallbacksOverride.ts
+++ b/src/Overrides/LocationCallbacksOverride.ts
@@ -1,0 +1,70 @@
+import { DependencyContainer } from "tsyringe";
+import { StayInTarkovMod } from "../StayInTarkovMod";
+import { LocationCallbacks } from "@spt-aki/callbacks/LocationCallbacks";
+import { LocationController } from "@spt-aki/controllers/LocationController";
+import { IGetLocationRequestData } from "@spt-aki/models/eft/location/IGetLocationRequestData";
+import { HttpResponseUtil } from "@spt-aki/utils/HttpResponseUtil";
+
+export class LocationCallbacksOverride
+{   
+    container: DependencyContainer;
+    locationController: LocationController;
+    httpResponse: HttpResponseUtil;
+
+    locationData: object = {};
+
+    constructor
+    (
+        container: DependencyContainer,
+    )
+    {
+        this.container = container;
+        this.locationController = container.resolve<LocationController>("LocationController");
+        this.httpResponse = container.resolve<HttpResponseUtil>("HttpResponseUtil");
+    }
+
+    public generateNewLootForLocation(sessionID: string, request: IGetLocationRequestData) {
+
+        if(this.locationData[request.locationId] === undefined)
+            this.locationData[request.locationId] = {};
+
+        this.locationData[request.locationId].Data = this.locationController.get(sessionID, request);
+        
+        // const ownedCoopMatch = this.getCoopMatch(sessionID);
+
+        const ownedCoopMatch = StayInTarkovMod.Instance.getCoopMatch(`pmc${sessionID}`);
+        if(ownedCoopMatch !== undefined) {
+            ownedCoopMatch.Loot = this.locationData[request.locationId].Loot;
+        }
+        else {
+            // console.warn(`Could not save Location Loot for match ${sessionID}. Unable to find Match.`);
+        }
+    }
+
+    public override(): void 
+    {
+        this.container.afterResolution("LocationCallbacks", (_t, result: LocationCallbacks) => {
+
+             result.getLocation = (url: string, info: IGetLocationRequestData, sessionID: string) => {
+
+
+                // This is HACK to test out getting same loot on multiple clients
+                if (this.locationData[info.locationId] === undefined) {
+                    console.log(`No cached locationData found for ${info.locationId}. Creating it now!`);
+                    this.generateNewLootForLocation(sessionID, info);
+                    this.locationData[info.locationId].Loot = this.locationData[info.locationId].Data.Loot;
+                }
+
+                // // This is a HACK. For some reason (not figured out yet) the Loot field empties after it has been generated. So refilling it here.
+                if (this.locationData[info.locationId].Data.Loot.length === 0) 
+                {
+                    this.locationData[info.locationId].Data.Loot = this.locationData[info.locationId].Loot;
+                }
+
+                return this.httpResponse.getBody(this.locationData[info.locationId].Data);
+
+            }
+
+        }, {frequency: "Always"});
+    }
+}

--- a/src/Overrides/LocationControllerOverride.ts
+++ b/src/Overrides/LocationControllerOverride.ts
@@ -1,0 +1,38 @@
+import { LocationController } from "@spt-aki/controllers/LocationController";
+import { IGetLocationRequestData } from "@spt-aki/models/eft/location/IGetLocationRequestData";
+import { DependencyContainer } from "tsyringe";
+
+export class LocationControllerOverride
+{   
+    container: DependencyContainer;
+    locationData: object = {};
+    
+    constructor
+    (
+        container: DependencyContainer
+    )
+    {
+        this.container = container;
+    }
+
+    public override(): void 
+    {
+
+        this.container.afterResolution("LocationController", (_t, result: LocationController) => {
+
+            result.get = (sessionId: string, request: IGetLocationRequestData) => {
+
+                if (this.locationData[request.locationId] === undefined) {
+
+                    // const name = location.toLowerCase().replace(" ", "");
+                    // this.locationData2[location] = result.generate(name);
+                    this.locationData[request.locationId] = result.get(sessionId, request);
+                }
+                
+                return this.locationData[request.locationId];
+            }
+
+
+        }, {frequency: "Always"});
+    }
+}


### PR DESCRIPTION
This PR makes it so you now require a password to log in in order to receive a session ID. Most account operations such as profile wipe, change password, etc. requires a successful login, so this will prevent any malicious operations from succeeding. After raid profile save requires a session ID which can only be obtained if you log in (with a password).

Launchers will now need to be able to process the "INVALID_PASSWORD" return value when querying /launcher/profile/login for instances where the password provided is incorrect or missing.

The overrides now have been refactored in their own classes for code clarity and simplicity.