### PR TITLE
WIP: Fix time acceleration desync between multiple clients

### DIFF
--- a/src/Extentions/CoopGameController.ts
+++ b/src/Extentions/CoopGameController.ts
@@ -1,0 +1,148 @@
+import { inject, injectable } from "tsyringe";
+
+import { GameController } from "@spt-aki/controllers/GameController";
+import { ApplicationContext } from "@spt-aki/context/ApplicationContext";
+import { ContextVariableType } from "@spt-aki/context/ContextVariableType";
+import { HideoutHelper } from "@spt-aki/helpers/HideoutHelper";
+import { HttpServerHelper } from "@spt-aki/helpers/HttpServerHelper";
+import { ProfileHelper } from "@spt-aki/helpers/ProfileHelper";
+import { PreAkiModLoader } from "@spt-aki/loaders/PreAkiModLoader";
+import { IEmptyRequestData } from "@spt-aki/models/eft/common/IEmptyRequestData";
+import { ILooseLoot } from "@spt-aki/models/eft/common/ILooseLoot";
+import { IPmcData } from "@spt-aki/models/eft/common/IPmcData";
+import { BodyPartHealth } from "@spt-aki/models/eft/common/tables/IBotBase";
+import { ICheckVersionResponse } from "@spt-aki/models/eft/game/ICheckVersionResponse";
+import { ICurrentGroupResponse } from "@spt-aki/models/eft/game/ICurrentGroupResponse";
+import { IGameConfigResponse } from "@spt-aki/models/eft/game/IGameConfigResponse";
+import { IGameKeepAliveResponse } from "@spt-aki/models/eft/game/IGameKeepAliveResponse";
+import { IServerDetails } from "@spt-aki/models/eft/game/IServerDetails";
+import { IAkiProfile } from "@spt-aki/models/eft/profile/IAkiProfile";
+import { AccountTypes } from "@spt-aki/models/enums/AccountTypes";
+import { ConfigTypes } from "@spt-aki/models/enums/ConfigTypes";
+import { SkillTypes } from "@spt-aki/models/enums/SkillTypes";
+import { Traders } from "@spt-aki/models/enums/Traders";
+import { ICoreConfig } from "@spt-aki/models/spt/config/ICoreConfig";
+import { IHttpConfig } from "@spt-aki/models/spt/config/IHttpConfig";
+import { ILocationConfig } from "@spt-aki/models/spt/config/ILocationConfig";
+import { ILootConfig } from "@spt-aki/models/spt/config/ILootConfig";
+import { IPmcConfig } from "@spt-aki/models/spt/config/IPmcConfig";
+import { IRagfairConfig } from "@spt-aki/models/spt/config/IRagfairConfig";
+import { ILocationData } from "@spt-aki/models/spt/server/ILocations";
+import { ILogger } from "@spt-aki/models/spt/utils/ILogger";
+import { ConfigServer } from "@spt-aki/servers/ConfigServer";
+import { DatabaseServer } from "@spt-aki/servers/DatabaseServer";
+import { CustomLocationWaveService } from "@spt-aki/services/CustomLocationWaveService";
+import { GiftService } from "@spt-aki/services/GiftService";
+import { ItemBaseClassService } from "@spt-aki/services/ItemBaseClassService";
+import { LocalisationService } from "@spt-aki/services/LocalisationService";
+import { OpenZoneService } from "@spt-aki/services/OpenZoneService";
+import { ProfileFixerService } from "@spt-aki/services/ProfileFixerService";
+import { SeasonalEventService } from "@spt-aki/services/SeasonalEventService";
+import { HashUtil } from "@spt-aki/utils/HashUtil";
+import { JsonUtil } from "@spt-aki/utils/JsonUtil";
+import { RandomUtil } from "@spt-aki/utils/RandomUtil";
+import { TimeUtil } from "@spt-aki/utils/TimeUtil";
+import { RaidTimeAdjustmentService } from "@spt-aki/services/RaidTimeAdjustmentService";
+
+@injectable()
+export class CoopGameController extends GameController
+{
+    protected static sessionBackendUrl: Record<string, string> = {};
+    
+    constructor
+    (
+        @inject("WinstonLogger") protected logger: ILogger,
+        @inject("DatabaseServer") protected databaseServer: DatabaseServer,
+        @inject("JsonUtil") protected jsonUtil: JsonUtil,
+        @inject("TimeUtil") protected timeUtil: TimeUtil,
+        @inject("HashUtil") protected hashUtil: HashUtil,
+        @inject("PreAkiModLoader") protected preAkiModLoader: PreAkiModLoader,
+        @inject("HttpServerHelper") protected httpServerHelper: HttpServerHelper,
+        @inject("RandomUtil") protected randomUtil: RandomUtil,
+        @inject("HideoutHelper") protected hideoutHelper: HideoutHelper,
+        @inject("ProfileHelper") protected profileHelper: ProfileHelper,
+        @inject("ProfileFixerService") protected profileFixerService: ProfileFixerService,
+        @inject("LocalisationService") protected localisationService: LocalisationService,
+        @inject("CustomLocationWaveService") protected customLocationWaveService: CustomLocationWaveService,
+        @inject("OpenZoneService") protected openZoneService: OpenZoneService,
+        @inject("SeasonalEventService") protected seasonalEventService: SeasonalEventService,
+        @inject("ItemBaseClassService") protected itemBaseClassService: ItemBaseClassService,
+        @inject("GiftService") protected giftService: GiftService,
+        @inject("RaidTimeAdjustmentService") protected raidTimeAdjustmentService: RaidTimeAdjustmentService,
+        @inject("ApplicationContext") protected applicationContext: ApplicationContext,
+        @inject("ConfigServer") protected configServer: ConfigServer
+    )
+    {
+        super(logger
+            , databaseServer
+            , jsonUtil
+            , timeUtil
+            , hashUtil
+            , preAkiModLoader
+            , httpServerHelper
+            , randomUtil
+            , hideoutHelper
+            , profileHelper
+            , profileFixerService
+            , localisationService
+            , customLocationWaveService
+            , openZoneService
+            , seasonalEventService
+            , itemBaseClassService
+            , giftService
+            , raidTimeAdjustmentService
+            , applicationContext
+            , configServer)
+    }
+
+    public setSessionBackendUrl(sessionID: string, backendUrl: string): void
+    {
+        this.logger.info("setSessionBackendUrl, Backend URL: " + backendUrl)
+        CoopGameController.sessionBackendUrl[sessionID] = backendUrl;
+    }
+
+    public override getGameConfig(sessionID: string): IGameConfigResponse
+    {
+        const backendUrl = CoopGameController.sessionBackendUrl[sessionID];
+        delete CoopGameController.sessionBackendUrl[sessionID];
+        this.logger.info("GetConfig, Backend URL: " + backendUrl)
+
+        const profile = this.profileHelper.getPmcProfile(sessionID);
+
+        const config: IGameConfigResponse = {
+            languages: this.databaseServer.getTables().locales.languages,
+            ndaFree: false,
+            reportAvailable: false,
+            twitchEventMember: false,
+            lang: "en",
+            aid: profile.aid,
+            taxonomy: 6,
+            activeProfileId: `pmc${sessionID}`,
+            backend: {
+                Lobby: backendUrl,
+                Trading: backendUrl,
+                Messaging: backendUrl,
+                Main: backendUrl,
+                RagFair: backendUrl,
+            },
+            useProtobuf: false,
+            utc_time: new Date().getTime() / 1000,
+            totalInGame: profile.Stats?.Eft?.TotalInGameTime ?? 0
+        };
+
+        return config;
+    }
+    
+    public override gameStart(_url: string, _info: IEmptyRequestData, sessionID: string, startTimeStampMS: number): void
+    {
+        const today = new Date().toUTCString();
+        const startTimeStampMS1 = Date.parse(today);
+
+        this.logger.info("gameStart, cachedIndexedTimestamp: " 
+        + sessionID + ", " 
+        + startTimeStampMS1)
+        this.applicationContext.addValue(ContextVariableType.CLIENT_START_TIMESTAMP, { sessionId: sessionID, timestamp: startTimeStampMS1 });
+        
+        super.gameStart(_url, _info, sessionID, startTimeStampMS1);
+    }
+}

--- a/src/Extentions/CoopWeatherController.ts
+++ b/src/Extentions/CoopWeatherController.ts
@@ -1,0 +1,33 @@
+import { inject, injectable } from "tsyringe";
+
+import { WeatherController } from "@spt-aki/controllers/WeatherController";
+import { IWeatherData } from "@spt-aki/models/eft/weather/IWeatherData";
+import { ILogger } from "@spt-aki/models/spt/utils/ILogger";
+import { ConfigServer } from "@spt-aki/servers/ConfigServer";
+
+import { CoopWeatherGenerator } from "./CoopWeatherGenerator";
+
+@injectable()
+export class CoopWeatherController extends WeatherController
+{    
+    constructor(
+        @inject("WeatherGenerator") protected weatherGenerator: CoopWeatherGenerator,
+        @inject("WinstonLogger") protected logger: ILogger,
+        @inject("ConfigServer") protected configServer: ConfigServer
+    )
+    {
+        super(weatherGenerator, logger, configServer)
+    }
+
+    /** Handle client/weather */
+    public override generate(sessionId?: string): IWeatherData
+    {
+        this.logger.info("Multiplayer Weather Controller Reached")
+        let result: IWeatherData = { acceleration: 0, time: "", date: "", weather: null };
+
+        result = this.weatherGenerator.calculateGameTime(result, sessionId);
+        result.weather = this.weatherGenerator.generateWeather(sessionId);
+
+        return result;
+    }
+}

--- a/src/Extentions/CoopWeatherGenerator.ts
+++ b/src/Extentions/CoopWeatherGenerator.ts
@@ -1,0 +1,179 @@
+import { inject, injectable } from "tsyringe";
+
+import { WeatherGenerator } from "@spt-aki/generators/WeatherGenerator";
+import { ApplicationContext } from "@spt-aki/context/ApplicationContext";
+import { ContextVariableType } from "@spt-aki/context/ContextVariableType";
+import { ConfigServer } from "@spt-aki/servers/ConfigServer";
+import { WeightedRandomHelper } from "@spt-aki/helpers/WeightedRandomHelper";
+import { IWeather, IWeatherData } from "@spt-aki/models/eft/weather/IWeatherData";
+import { ILogger } from "@spt-aki/models/spt/utils/ILogger";
+import { RandomUtil } from "@spt-aki/utils/RandomUtil";
+import { TimeUtil } from "@spt-aki/utils/TimeUtil";
+
+@injectable()
+export class CoopWeatherGenerator extends WeatherGenerator
+{
+    
+    constructor
+    (
+        @inject("WeightedRandomHelper") protected weightedRandomHelper: WeightedRandomHelper,
+        @inject("WinstonLogger") protected logger: ILogger,
+        @inject("RandomUtil") protected randomUtil: RandomUtil,
+        @inject("TimeUtil") protected timeUtil: TimeUtil,
+        @inject("ApplicationContext") protected applicationContext: ApplicationContext,
+        @inject("ConfigServer") protected configServer: ConfigServer,
+    )
+    {
+        super(weightedRandomHelper, logger, randomUtil, timeUtil, applicationContext, configServer)
+    }
+
+    public override calculateGameTime(data: IWeatherData, sessionId?:string): IWeatherData
+    {
+        this.logger.info("Multiplayer Weather Generator Reached: calculateGameTime")
+        this.logger.info("calculateGameTime, sessionId: " + sessionId);
+        const computedDate = new Date();
+        const formattedDate = this.timeUtil.formatDate(computedDate);
+
+        data.date = formattedDate;
+        data.time = this.getBsgFormattedInRaidTime(computedDate, sessionId);
+        data.acceleration = this.weatherConfig.acceleration;
+
+        return data;
+    }
+    
+    protected override getBsgFormattedInRaidTime(currentDate: Date, sessionId?:string): string
+    {
+        this.logger.info("Multiplayer Weather Generator Reached: getBsgFormattedInRaidTime")
+        this.logger.info("getBsgFormattedInRaidTime, sessionId: " + sessionId);
+        const clientAcceleratedDate = this.getInRaidTime(currentDate, sessionId, false);
+
+        return this.getBSGFormattedTime(clientAcceleratedDate);
+    }
+
+    public recordKeys<K extends PropertyKey, T>(object: Record<K, T>) : K[] 
+    {
+        return Object.keys(object) as (K)[];
+    }
+
+    public override getInRaidTime(currentDate: Date, sessionId?:string, logMe?: boolean): Date 
+    {
+        this.logger.info("Multiplayer Weather Generator Reached: getInRaidTime")
+        // Get timestamp of when client connected to server
+        const contextVariable = this.applicationContext.getLatestValue(ContextVariableType.CLIENT_START_TIMESTAMP);
+        const timestampRecord = contextVariable.getValue<Record<string, number>>()
+        const gameStartTimeStampMS = timestampRecord[sessionId];
+
+        if (logMe) 
+        {
+            this.logger.info("getInRaidTime, sessionId: " + sessionId);
+            this.logger.info("contextVariable: " + typeof contextVariable);
+            this.logger.info("timestampRecord: " + typeof timestampRecord);
+            this.logger.info("entries timestampRecord: " + this.recordKeys(timestampRecord).length.toString());
+            this.recordKeys(timestampRecord).forEach((key) => this.logger.info(key));
+            this.logger.info("getInRaidTime, timestampRecord Attempt: " 
+                + sessionId + ", " 
+                + gameStartTimeStampMS)
+        }
+
+        // Get delta between now and when client connected to server in milliseconds
+        const deltaMSFromNow = currentDate.getTime() - gameStartTimeStampMS;
+        const acceleratedMS = deltaMSFromNow * (this.weatherConfig.acceleration);
+
+        // Match client side time calculations which start from the current date + connection time, not current time
+        const locationTime = new Date(gameStartTimeStampMS);
+        locationTime.setFullYear(currentDate.getFullYear());
+        locationTime.setMonth(currentDate.getMonth());
+        locationTime.setDate(currentDate.getDate());
+
+        const clientAcceleratedDate = new Date(locationTime.getTime() + acceleratedMS);
+        
+        if (logMe) 
+        {
+            this.logger.info("Server Time Sync Values:");
+
+            const connectionTime = new Date(gameStartTimeStampMS);
+
+            let connectionDiff = deltaMSFromNow;
+            const connectionTimeH = Math.floor(connectionDiff / (1000 * 60 * 60));
+            connectionDiff -= connectionTimeH * (1000 * 60 * 60);
+            const connectionTimeM = Math.floor(connectionDiff / (1000 * 60));
+            connectionDiff -= connectionTimeM * (1000 * 60);
+            const connectionTimeS = Math.floor(connectionDiff / (1000));
+            connectionDiff -= connectionTimeS * (1000);
+
+            let acceleratedDiff = acceleratedMS;
+            const acceleratedTimeH = Math.floor(acceleratedDiff / (1000 * 60 * 60));
+            acceleratedDiff -= acceleratedTimeH * (1000 * 60 * 60);
+            const acceleratedTimeM = Math.floor(acceleratedDiff / (1000 * 60));
+            acceleratedDiff -= acceleratedTimeM * (1000 * 60);
+            const acceleratedTimeS = Math.floor(acceleratedDiff / (1000));
+            acceleratedDiff -= acceleratedTimeS * (1000);
+
+            this.logger.info(
+                "Now: " + currentDate.toDateString() + " "
+                    + currentDate.toLocaleTimeString("en-US", { hour12: false })
+                    + ", Connection Time: " + connectionTime.toDateString() + " "
+                    + connectionTime.toLocaleTimeString("en-US", { hour12: false })
+                    + ", Delta: " + connectionTimeH
+                    + ":" + connectionTimeM + ":" + connectionTimeS.toString()
+            );
+            this.logger.info(
+                "Today/Location Time: " + locationTime.toDateString() + " "
+                    + locationTime.toLocaleTimeString("en-US", { hour12: false }) + ", Accelerated Delta: "
+                    + acceleratedTimeH.toString() + ":"
+                    + acceleratedTimeM.toString() + ":" + acceleratedTimeS.toString()
+            );
+            this.logger.info(
+                "Accelerated Time:" + clientAcceleratedDate.toDateString() + " "
+                    + clientAcceleratedDate.toLocaleTimeString("en-US", { hour12: false }) + ", "
+                    + "Acceleration: " + this.weatherConfig.acceleration.toString()
+            );
+        }
+
+        return clientAcceleratedDate;
+    }
+
+    public override generateWeather(sessionId?:string): IWeather
+    {
+        this.logger.info("Multiplayer Weather Generator Reached: generateWeather")
+        this.logger.info("generateWeather, sessionId: " + sessionId);
+        const rain = this.getWeightedRain();
+
+        const result: IWeather = {
+            cloud: this.getWeightedClouds(),
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            wind_speed: this.getWeightedWindSpeed(),
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            wind_direction: this.getWeightedWindDirection(),
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            wind_gustiness: this.getRandomFloat("windGustiness"),
+            rain: rain,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            rain_intensity: (rain > 1) ? this.getRandomFloat("rainIntensity") : 0,
+            fog: this.getWeightedFog(),
+            temp: this.getRandomFloat("temp"),
+            pressure: this.getRandomFloat("pressure"),
+            time: "",
+            date: "",
+            timestamp: 0,
+        };
+
+        this.setCurrentDateTime(result, sessionId);
+
+        return result;
+    }
+
+    protected override setCurrentDateTime(weather: IWeather, sessionId?:string): void
+    {
+        this.logger.info("Multiplayer Weather Generator Reached: setCurrentDateTime")
+        this.logger.info("setCurrentDateTime, sessionId: " + sessionId);
+        const currentDate = this.getInRaidTime(new Date(), sessionId, true);
+        const normalTime = this.getBSGFormattedTime(currentDate);
+        const formattedDate = this.timeUtil.formatDate(currentDate);
+        const datetime = `${formattedDate} ${normalTime}`;
+
+        weather.timestamp = Math.floor(currentDate.getTime() / 1000); // matches weather.date
+        weather.date = formattedDate; // matches weather.timestamp
+        weather.time = datetime; // matches weather.timestamp
+    }
+}

--- a/src/Overrides/ApplicationContextOverride.ts
+++ b/src/Overrides/ApplicationContextOverride.ts
@@ -1,0 +1,104 @@
+import { DependencyContainer } from "tsyringe";
+
+import { ApplicationContext } from "@spt-aki/context/ApplicationContext";
+import { ContextVariable } from "@spt-aki/context/ContextVariable";
+import { ContextVariableType } from "@spt-aki/context/ContextVariableType";
+import { LinkedList } from "@spt-aki/utils/collections/lists/LinkedList";
+import { ILogger } from "@spt-aki/models/spt/utils/ILogger";
+
+export class ApplicationContextOverride
+{
+    container: DependencyContainer;
+
+    logger: ILogger;
+    
+    private variables = new Map<ContextVariableType, LinkedList<ContextVariable>>();
+    private clientTimestamps: Record<string, number> = {};
+
+    private static holderMaxSize = 10;
+    
+    constructor
+    (
+        container: DependencyContainer
+    )
+    {
+        this.container = container;
+        this.logger = container.resolve<ILogger>("WinstonLogger");
+    }
+
+    public override(): void 
+    {
+        this.container.afterResolution("ApplicationContext", (_t, result: ApplicationContext) => 
+        {
+            result.getLatestValue = (type: ContextVariableType): ContextVariable => 
+            {
+                if (type === ContextVariableType.CLIENT_START_TIMESTAMP) 
+                {
+                    return new ContextVariable(this.clientTimestamps, ContextVariableType.CLIENT_START_TIMESTAMP);
+                }
+
+                if (this.variables.has(type))
+                {
+                    return this.variables.get(type)?.getTail()?.getValue();
+                }
+        
+                return undefined;
+            }
+            
+            result.getValues = (type: ContextVariableType): ContextVariable[] => 
+            {
+                if (this.variables.has(type))
+                {
+                    return this.variables.get(type).toList();
+                }
+        
+                return undefined;
+            }
+            
+            result.addValue = (type: ContextVariableType, value: any): void => 
+            {
+                let list: LinkedList<ContextVariable>;
+                if (this.variables.has(type))
+                {
+                    list = this.variables.get(type);
+                }
+                else
+                {
+                    list = new LinkedList<ContextVariable>();
+                }
+        
+                if (list.getSize() >= ApplicationContextOverride.holderMaxSize)
+                {
+                    list.removeFirst();
+                }
+
+                if (type === ContextVariableType.CLIENT_START_TIMESTAMP) 
+                {
+                    if (typeof value === "number") 
+                    {
+                        // ignore SPT usecase
+                        this.logger.info("Ignored Old Timestamp Storage")
+                        return;
+                    }
+
+                    this.logger.info("Storing Timestamp, entries: " + Object.keys(this.clientTimestamps).length.toString())
+                    this.clientTimestamps[value.sessionId] = value.timestamp;
+                    this.logger.info("Stored Timestamp, entries: " + Object.keys(this.clientTimestamps).length.toString())
+                    return;
+                }
+
+                list.add(new ContextVariable(value, type));
+                this.variables.set(type, list);
+            }
+            
+            result.clearValues = (type: ContextVariableType): void => 
+            {
+                if (this.variables.has(type))
+                {
+                    this.variables.delete(type);
+                }
+            }
+            
+        }, {frequency: "Always"});
+    }
+}

--- a/src/Overrides/BundleLoaderOverride.ts
+++ b/src/Overrides/BundleLoaderOverride.ts
@@ -51,9 +51,6 @@ export class BundleLoaderOverride
 
     public getBundle(key: string, local: boolean): BundleInfo
     {
-        //decode the bundle key name to support spaces, etc.
-        key = decodeURI(key);
-        
         const bundle = this.jsonUtil.clone(this.bundles[key]);
 
         if (local)

--- a/src/Overrides/GameControllerOverride.ts
+++ b/src/Overrides/GameControllerOverride.ts
@@ -1,5 +1,6 @@
 import { DependencyContainer } from "tsyringe";
 import { GameController } from "@spt-aki/controllers/GameController";
+import { ApplicationContext } from "@spt-aki/context/ApplicationContext";
 import { IGameConfigResponse } from "@spt-aki/models/eft/game/IGameConfigResponse";
 import { ProfileHelper } from "@spt-aki/helpers/ProfileHelper";
 import { DatabaseServer } from "@spt-aki/servers/DatabaseServer";
@@ -10,12 +11,13 @@ export class GameControllerOverride
 
     profileHelper: ProfileHelper;
     databaseServer: DatabaseServer;
+    applicationContext: ApplicationContext;
     
     protected sessionBackendUrl: Record<string, string> = {};
     
     constructor
     (
-        container: DependencyContainer
+        container: DependencyContainer,
     )
     {
         this.container = container;
@@ -70,6 +72,7 @@ export class GameControllerOverride
 
                 return this.getGameConfig(sessionID, backendUrl);
             }
+
             // The modifier Always makes sure this replacement method is ALWAYS replaced
         }, {frequency: "Always"});
     }

--- a/src/Overrides/LauncherControllerOverride.ts
+++ b/src/Overrides/LauncherControllerOverride.ts
@@ -1,30 +1,30 @@
 import { DependencyContainer } from "tsyringe";
-import { ILoginRequestData } from "@spt-aki/models/eft/launcher/ILoginRequestData";
 import { SaveServer } from "@spt-aki/servers/SaveServer";
 import { LauncherController } from "@spt-aki/controllers/LauncherController";
 import { CoopConfig } from "./../CoopConfig";
-import { GameControllerOverride } from "./GameControllerOverride";
-import { SITHelpers } from "./../SITHelpers"
+import { CoopGameController } from "src/Extentions/CoopGameController";
+import { ILogger } from "@spt-aki/models/spt/utils/ILogger";
 
 export class LauncherControllerOverride
 {
     container: DependencyContainer;
     saveServer: SaveServer;
-    gameControllerOverride: GameControllerOverride;
+    coopGameController: CoopGameController;
     coopConfig: CoopConfig;
     httpConfig: any;
+    logger:ILogger;
     
     constructor
     (
         container: DependencyContainer,
-        gameControllerOverride: GameControllerOverride,
         coopConfig: CoopConfig,
         httpConfig: any
     )
     {
         this.container = container;
         this.saveServer = container.resolve<SaveServer>("SaveServer");
-        this.gameControllerOverride = gameControllerOverride;
+        this.coopGameController = container.resolve<CoopGameController>("CoopGameController");
+        this.logger = container.resolve<ILogger>("WinstonLogger");
         this.coopConfig = coopConfig;
         this.httpConfig = httpConfig;
     }
@@ -46,7 +46,8 @@ export class LauncherControllerOverride
                         backendUrl = info.backendUrl;
                     }
 
-                    this.gameControllerOverride.setSessionBackendUrl(sessionID, backendUrl);
+                    this.logger.info("login, Backend URL: " + backendUrl)
+                    this.coopGameController.setSessionBackendUrl(sessionID, backendUrl);
                     
                     return sessionID;
                 }
@@ -67,7 +68,6 @@ export class LauncherControllerOverride
             // /launcher/profile/login
             result.login = (info: any) =>
             {
-
                 return this.login(info);
             }
         }, {frequency: "Always"});

--- a/src/Overrides/WeatherCallbacksOverride.ts
+++ b/src/Overrides/WeatherCallbacksOverride.ts
@@ -1,0 +1,42 @@
+import { DependencyContainer } from "tsyringe";
+
+import { WeatherCallbacks } from "@spt-aki/callbacks/WeatherCallbacks";
+import { IEmptyRequestData } from "@spt-aki/models/eft/common/IEmptyRequestData";
+import { IGetBodyResponseData } from "@spt-aki/models/eft/httpResponse/IGetBodyResponseData";
+import { IWeatherData } from "@spt-aki/models/eft/weather/IWeatherData";
+import { HttpResponseUtil } from "@spt-aki/utils/HttpResponseUtil";
+import { ILogger } from "@spt-aki/models/spt/utils/ILogger";
+
+import { CoopWeatherController } from "../Extentions/CoopWeatherController";
+
+export class WeatherCallbacksOverride
+{
+    container: DependencyContainer;
+
+    logger: ILogger;
+    httpResponse: HttpResponseUtil;
+    weatherController: CoopWeatherController;
+    
+    constructor
+    (
+        container: DependencyContainer
+    )
+    {
+        this.container = container;
+        this.httpResponse = container.resolve<HttpResponseUtil>("HttpResponseUtil");
+        this.weatherController = container.resolve<CoopWeatherController>("CoopWeatherController");
+        this.logger = container.resolve<ILogger>("WinstonLogger");
+    }
+
+    public override(): void 
+    {
+        this.container.afterResolution("WeatherCallbacks", (_t, result: WeatherCallbacks) => 
+        {
+            result.getWeather = (url: string, info: IEmptyRequestData, sessionID: string): IGetBodyResponseData<IWeatherData> => 
+            {
+                this.logger.info("Multiplayer Weather Callback Reached")
+                return this.httpResponse.getBody(this.weatherController.generate(sessionID));
+            }
+        }, {frequency: "Always"});
+    }
+}

--- a/types/context/ApplicationContext.d.ts
+++ b/types/context/ApplicationContext.d.ts
@@ -17,4 +17,5 @@ export declare class ApplicationContext {
     getLatestValue(type: ContextVariableType): ContextVariable;
     getValues(type: ContextVariableType): ContextVariable[];
     addValue(type: ContextVariableType, value: any): void;
+    clearValues(type: ContextVariableType): void;
 }

--- a/types/controllers/GameController.d.ts
+++ b/types/controllers/GameController.d.ts
@@ -27,6 +27,7 @@ import { LocalisationService } from "../services/LocalisationService";
 import { OpenZoneService } from "../services/OpenZoneService";
 import { ProfileFixerService } from "../services/ProfileFixerService";
 import { SeasonalEventService } from "../services/SeasonalEventService";
+import { RaidTimeAdjustmentService } from "../services/RaidTimeAdjustmentService";
 import { HashUtil } from "../utils/HashUtil";
 import { JsonUtil } from "../utils/JsonUtil";
 import { RandomUtil } from "../utils/RandomUtil";
@@ -58,7 +59,7 @@ export declare class GameController {
     protected ragfairConfig: IRagfairConfig;
     protected pmcConfig: IPmcConfig;
     protected lootConfig: ILootConfig;
-    constructor(logger: ILogger, databaseServer: DatabaseServer, jsonUtil: JsonUtil, timeUtil: TimeUtil, hashUtil: HashUtil, preAkiModLoader: PreAkiModLoader, httpServerHelper: HttpServerHelper, randomUtil: RandomUtil, hideoutHelper: HideoutHelper, profileHelper: ProfileHelper, profileFixerService: ProfileFixerService, localisationService: LocalisationService, customLocationWaveService: CustomLocationWaveService, openZoneService: OpenZoneService, seasonalEventService: SeasonalEventService, itemBaseClassService: ItemBaseClassService, giftService: GiftService, applicationContext: ApplicationContext, configServer: ConfigServer);
+    constructor(logger: ILogger, databaseServer: DatabaseServer, jsonUtil: JsonUtil, timeUtil: TimeUtil, hashUtil: HashUtil, preAkiModLoader: PreAkiModLoader, httpServerHelper: HttpServerHelper, randomUtil: RandomUtil, hideoutHelper: HideoutHelper, profileHelper: ProfileHelper, profileFixerService: ProfileFixerService, localisationService: LocalisationService, customLocationWaveService: CustomLocationWaveService, openZoneService: OpenZoneService, seasonalEventService: SeasonalEventService, itemBaseClassService: ItemBaseClassService, giftService: GiftService, raidTimeAdjustmentService:RaidTimeAdjustmentService, applicationContext: ApplicationContext, configServer: ConfigServer);
     load(): void;
     /**
      * Handle client/game/start

--- a/types/models/eft/game/IGetRaidTimeRequest.d.ts
+++ b/types/models/eft/game/IGetRaidTimeRequest.d.ts
@@ -1,0 +1,5 @@
+export interface IGetRaidTimeRequest
+{
+    Side: string,
+    Location: string
+}

--- a/types/models/eft/game/IGetRaidTimeResponse.d.ts
+++ b/types/models/eft/game/IGetRaidTimeResponse.d.ts
@@ -1,0 +1,15 @@
+export interface IGetRaidTimeResponse
+{
+    RaidTimeMinutes: number
+    NewSurviveTimeSeconds: number
+    OriginalSurvivalTimeSeconds: number
+    ExitChanges: ExtractChange[]
+}
+
+export interface ExtractChange
+{
+    Name: string
+    MinTime?: number
+    MaxTime?: number
+    Chance?: number
+}

--- a/types/models/spt/config/ILocationConfig.d.ts
+++ b/types/models/spt/config/ILocationConfig.d.ts
@@ -86,3 +86,19 @@ export interface LootMultiplier {
     terminal: number;
     town: number;
 }
+
+export interface IScavRaidTimeLocationSettings
+{
+    /** Should loot be reduced by same percent length of raid is reduced by */
+    reduceLootByPercent: boolean;
+    /** Smallest % of container loot that should be spawned */
+    minStaticLootPercent: number;
+/** Smallest % of loose loot that should be spawned */
+    minDynamicLootPercent: number;
+    /** Chance raid time is reduced */
+    reducedChancePercent: number;
+    /** How much should raid time be reduced - weighted */
+    reductionPercentWeights: Record<string, number>;
+    /** Should bot waves be removed / spawn times be adjusted */
+    adjustWaves: boolean;
+}

--- a/types/models/spt/location/IRaidChanges.d.ts
+++ b/types/models/spt/location/IRaidChanges.d.ts
@@ -1,0 +1,9 @@
+export interface IRaidChanges
+{
+    /** What percentage of dynamic loot should the map contain */
+    dynamicLootPercent: number
+    /** What percentage of static loot should the map contain */
+    staticLootPercent: number
+    /** How many seconds into the raid is the player simulated to spawn in at */
+    simulatedRaidStartSeconds: number
+}

--- a/types/services/RaidTimeAdjustmentService.d.ts
+++ b/types/services/RaidTimeAdjustmentService.d.ts
@@ -1,0 +1,70 @@
+import { inject, injectable } from "tsyringe";
+
+import { ApplicationContext } from "../context/ApplicationContext";
+import { WeightedRandomHelper } from "../helpers/WeightedRandomHelper";
+import { ILocationBase } from "../models/eft/common/ILocationBase";
+import { IGetRaidTimeRequest } from "../models/eft/game/IGetRaidTimeRequest";
+import { ExtractChange, IGetRaidTimeResponse } from "../models/eft/game/IGetRaidTimeResponse";
+import { ILocationConfig, IScavRaidTimeLocationSettings, LootMultiplier } from "../models/spt/config/ILocationConfig";
+import { IRaidChanges } from "../models/spt/location/IRaidChanges";
+import { ILogger } from "../models/spt/utils/ILogger";
+import { ConfigServer } from "../servers/ConfigServer";
+import { DatabaseServer } from "../servers/DatabaseServer";
+import { RandomUtil } from "../utils/RandomUtil";
+
+export declare class RaidTimeAdjustmentService
+{
+    protected locationConfig: ILocationConfig;
+
+    protected logger: ILogger;
+    protected databaseServer: DatabaseServer;
+    protected randomUtil: RandomUtil;
+    protected weightedRandomHelper: WeightedRandomHelper;
+    protected applicationContext: ApplicationContext;
+    protected configServer: ConfigServer;
+
+    /**
+     * Make alterations to the base map data passed in
+     * Loot multipliers/waves/wave start times
+     * @param raidAdjustments Changes to process on map
+     * @param mapBase Map to adjust
+     */
+    makeAdjustmentsToMap(raidAdjustments: IRaidChanges, mapBase: ILocationBase): void;
+
+    /**
+     * Adjust the loot multiplier values passed in to be a % of their original value
+     * @param mapLootMultiplers Multiplers to adjust
+     * @param loosePercent Percent to change values to
+     */
+    adjustLootMultipliers(mapLootMultiplers: LootMultiplier, loosePercent: number): void;
+
+    /**
+     * Adjust bot waves to act as if player spawned later
+     * @param mapBase map to adjust
+     * @param raidAdjustments Map adjustments
+     */
+    adjustWaves(mapBase: ILocationBase, raidAdjustments: IRaidChanges): void;
+
+    /**
+     * Create a randomised adjustment to the raid based on map data in location.json
+     * @param sessionId Session id
+     * @param request Raid adjustment request
+     * @returns Response to send to client
+     */
+    getRaidAdjustments(sessionId: string, request: IGetRaidTimeRequest): IGetRaidTimeResponse;
+
+    /**
+     * Get raid start time settings for specific map
+     * @param location Map Location e.g. bigmap
+     * @returns IScavRaidTimeLocationSettings
+     */
+    getMapSettings(location: string): IScavRaidTimeLocationSettings;
+
+    /**
+     * Adjust exit times to handle scavs entering raids part-way through
+     * @param mapBase Map base file player is on
+     * @param newRaidTimeMinutes How long raid is in minutes
+     * @returns List of  exit changes to send to client
+     */
+    getExitAdjustments(mapBase: ILocationBase, newRaidTimeMinutes: number): ExtractChange[];
+}


### PR DESCRIPTION
**This is still WIP and I'm looking for feedback and suggestions.**

The SPT server is not set up to calculate accelerated/inRaid time for more than one client.  This causes the issue where you choose a day raid and it is night or vice-versa.

*Current Progress*
These super hacky changes successfully track client connection timestamps on a per session basis, which ensures that the client and server always calculate the same accelerated time.  The issue currently is that the calculated time differs from client to client, which means the host will always have the right time, but other coop players can still be desynced.  If I can get the `Location Time` mentioned below in the client calculations synced up, it should fix the last of the desync.
Once it all works, I also want to reduce the footprint to something reasonable.

--------------
**Long Explanation**

The Tarkov client calculates current raid time (accelerated time/what you see at location selection)) via the following formula in Session.GetCurrentLocationTime():
`In Raid Time = Today's Date + Location Time + Time Since Client Connection * Acceleration`
_Note: So far I haven't figure out where `Location Time` gets set, but it doesn't change and is close enough to `Connection Time` that I just used `Connection Time` instead._

The current server release uses the following:
`In Raid Time = Current Date and Time + Time Since Latest Client Connection * (Acceleration - 1)`

While the latest server code has been updated to:
`In Raid Time = Today's Date + Connection Time + Time Since Latest Client Connection * Acceleration`
_Note: I wasn't able to figure out where `Location Time` gets set, but it doesn't change and is close enough to `Connection Time` that using `Connection Time` instead is fine in single player._

The key issue being that the `Latest Client Connection` will change as clients join and the stored value will only be correct for the most recently connected client.  Older clients will be out of sync by `(Their Connection Time - Latest Client Connection Time) * Acceleration`, which becomes significant very quickly at a 7x timescale.

-------------
In terms of SPT Code, the issue on the server seems to be half in `GameController.ts`:
```
public gameStart(_url: string, _info: IEmptyRequestData, sessionID: string, startTimeStampMS: number): void
    {
        // Store start time in app context
        this.applicationContext.addValue(ContextVariableType.CLIENT_START_TIMESTAMP, startTimeStampMS);
        ...
```

And then in WeatherGenerator.ts:
```
public getInRaidTime(currentDate: Date): Date
    {
        // Get timestamp of when client conneted to server
        const gameStartTimeStampMS = this.applicationContext.getLatestValue(ContextVariableType.CLIENT_START_TIMESTAMP)
            .getValue<number>();
        ...
```
With an addition hiccup being that the `WeatherGenerator` is never passed the `sessionId`, which presumably is needed to fetch a specific client's timestamp.

--------------
**Where I Could Use Help**

*EFT Code Knowledge* 
`BackendSession.LocationTime` - Where the does it get set?  I can't find it using dotPeek.  In testing, it was the client connection time +~90 seconds.  I think it's supposed to be the current accelerated server time, but I'll have to do more testing unless someone else can find where it's set.

*Making My Changes Prettier*
I think I could have made a pretty elegant solution if SIT was a fork of the SPT Server.  It is not.  Instead I have made a mess of my branch to get it working with my limited understanding of how to use IoC and tsyringe.  

- I don't like how many files I changed to pass `sessionId`s around.  That many override files just felt clunky, but I didn't see a better way.

- I don't like that I moved the existing `GameControllerOverride` into my changes.   I wanted to put my changes in the existing file, but couldn't see a way to run the original `gameStart()` before my per session timestamp caching.

- I noticed that the existing override files (ie. GameControllerOverride) do not use extension.  Is there a specific reason for that?  I wanted to match the existing code, but couldn't figure out how to do that and get the functionality I needed (specifically overloading function signatures for weather router/callbacks/controller/generators). 

I would absolutely love suggestions.  
