### PR TITLE
Create release ci build aki server on both linux and windows

### DIFF
--- a/.github/workflows/Create-Release-with-SPT-AKI-Integration.yaml
+++ b/.github/workflows/Create-Release-with-SPT-AKI-Integration.yaml
@@ -5,77 +5,38 @@ name: Create Release with SPT-AKI Integration on Windows
 
 jobs:
   build:
+    strategy:
+      matrix:
+        os: [ "ubuntu-latest", "windows-latest" ]
     permissions: write-all
     name: Create Release
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout SIT-Server-Mod Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: 'master'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20.10.0'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build SIT-Server-Mod
-        run: npm run build
 
       - name: Read package.json
         id: read_package_json
         run: echo "::set-output name=version::$(node -e 'console.log(require(`./package.json`).version)')"
 
-      - name: Clone SPT-AKI Server
-        run: |
-          git clone -b 3.8.0 --single-branch https://dev.sp-tarkov.com/SPT-AKI/Server.git SPT-AKI-Server
-          cd SPT-AKI-Server
-          git lfs fetch
-          git lfs pull
-
-      - name: Build SPT-AKI Server
-        run: |
-          cd SPT-AKI-Server\project
-          npm install
-          npm run build:release
+      - name: Build Release Package
+        id: build
         shell: pwsh
-
-      - name: Setup temporary directory for zipping
-        run: |
-          $tempPath = "tempZipContents"
-          New-Item -ItemType Directory -Force -Path $tempPath
-          New-Item -ItemType Directory -Force -Path "$tempPath\user\mods\SITCoop"
-        shell: pwsh
-        
-      - name: Copy build contents to temporary directory
-        run: |
-          Copy-Item -Path "SPT-AKI-Server\project\build\*" -Destination "tempZipContents" -Recurse
-        shell: pwsh
-        
-      - name: Copy SITCoop mod to temporary directory
-        run: |
-          Copy-Item -Path "SITCoop\*" -Destination "tempZipContents\user\mods\SITCoop" -Recurse
-        shell: pwsh
-  
-      - name: Zip the temporary directory
-        run: |
-          Compress-Archive -Path "tempZipContents\*" -DestinationPath "SPT-AKI-with-SITCoop.zip" -Force
-        shell: pwsh
-  
-      - name: Cleanup temporary directory
-        run: |
-          Remove-Item -Path "tempZipContents" -Recurse -Force
-        shell: pwsh
+        run: ./package_release_with_server.ps1 -Overwrite -Branch 3.8.0
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.read_package_json.outputs.version }}
           name: SPT-AKI-with-SITCoop-${{ github.run_number }}
-          files: SPT-AKI-with-SITCoop.zip
+          files: ${{ steps.build.outputs.ZIP_NAME }}
           draft: true
           prerelease: false
           generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ SITConfig*.json
 mod.js
 dist/
 *dynamicAssort.json
+Aki-Server
+SITCoop
+tempZipContents
+*.zip

--- a/packageBuild.ts
+++ b/packageBuild.ts
@@ -39,7 +39,8 @@ const ignoreList = [
     "packageBuild.ts",
     "mod.code-workspace",
     "package-lock.json",
-    "tsconfig.json"
+    "tsconfig.json",
+    "*.ps1"
 ];
 const exclude = glob.sync(`{${ignoreList.join(",")}}`, { realpath: true, dot: true });
 
@@ -65,6 +66,7 @@ const filesToRemove = [
     ".git/",
     ".gitea/",
     ".gitignore",
+    "package_release_with_server.ps1",
 ];
   
 filesToRemove.forEach((file) => {

--- a/package_release_with_server.ps1
+++ b/package_release_with_server.ps1
@@ -1,0 +1,118 @@
+Param(
+    [Parameter(Mandatory = $false)]
+    [Switch] $Overwrite,
+
+    [Parameter(Mandatory = $false)]
+    [string] $Branch,
+
+    [Parameter(Mandatory = $false)]
+    [string] $Commit
+)
+
+$ErrorActionPreference = "Stop"
+$SOURCE_REPO = "https://dev.sp-tarkov.com/SPT-AKI/Server.git"
+$SERVER_DIR = "./Aki-Server"
+$ZIP_Folder = "./tempZipContents"
+
+# build coop mod
+npm ci
+npm run build
+
+if ($LASTEXITCODE -ne 0) {
+    throw ("coop mod npm run build failed, exit code $LASTEXITCODE")
+}
+
+# clone aki server
+if (Test-Path -Path $SERVER_DIR) {
+    if ($Overwrite -or (Read-Host "$SERVER_DIR exists, delete? [y/n]") -eq 'y') {
+        Write-Output "$SERVER_DIR exists, removing"
+        Remove-Item -Recurse -Force $SERVER_DIR
+    }
+    else {
+        Exit 1
+    }
+}
+
+Write-Output "clone repo"
+if ( $Branch.Length -gt 0 ) {
+    Write-Output "Cloning branch/tag $Branch"
+    git clone --depth 1 -b $Branch $SOURCE_REPO $SERVER_DIR
+} 
+else {
+    Write-Output "Cloning default branch"
+    git clone --depth 1 $SOURCE_REPO $SERVER_DIR
+}
+
+Set-Location $SERVER_DIR
+
+if ($Commit.Length -gt 0) {
+    Write-Output "Checking out the commit $Commit"
+    git fetch --depth=1 $SOURCE_REPO $Commit
+    git checkout $Commit
+
+    if ($LASTEXITCODE -ne 0) {
+        throw ("Commit $Commit checkout failed. It doesn't exist? git exit code $LASTEXITCODE")
+    }
+}
+
+#$Head = git rev-parse --short HEAD
+#$Branch = git rev-parse --abbrev-ref HEAD
+#$CTime = git log -1 --format="%at"
+#$CTimeS = (([System.DateTimeOffset]::FromUnixTimeSeconds($CTime)).DateTime).ToString("yyyyMMddHHmmss")
+#
+#Write-Output "Current HEAD is at $Head in $Branch committed at $CTimeS"
+#
+#$Tag = git describe --tags --abbrev=0 $Head
+#$IsTag = $LASTEXITCODE -eq 0
+#if ($IsTag) {
+#    Write-Output "We also have a tag $Tag at HEAD"
+#}
+
+Write-Output "lfs"
+git lfs fetch
+git lfs pull
+
+Write-Output "build"
+Set-Location ./project
+npm install
+npm run build:release
+
+if ($LASTEXITCODE -ne 0) {
+    throw ("npm run build:$Target failed, exit code $LASTEXITCODE")
+}
+
+Get-ChildItem ./build
+#$AkiMeta = (Get-Content ./build/Aki_Data/Server/configs/core.json | ConvertFrom-Json -AsHashtable)
+#Write-Output $akiMeta
+#
+#if ($IsTag) {
+#    $CInfo = "tag-$Tag"
+#}
+#elseif ($Branch.Equals("HEAD")) {
+#    $CInfo = "$Head-$CTimeS"
+#}
+#else {
+#    $CInfo = "$Branch-$Head-$CTimeS"
+#}
+#
+#$Suffix = "$Target-v$($akimeta.akiVersion)-$CInfo-Tarkov$($akimeta.compatibleTarkovVersion)"
+
+Set-Location ../../
+
+New-Item -ItemType Directory -Force -Path "$ZIP_Folder/user/mods/"
+Copy-Item -Path "$SERVER_DIR/project/build\*" -Destination "$ZIP_Folder" -Recurse
+Copy-Item -Path "./SITCoop" -Destination "$ZIP_Folder/user/mods/" -Recurse
+
+# make release package
+if ($IsWindows) {
+    $ZipName = "Aki-Server-win-with-SITCoop.zip"
+    Compress-Archive -Path "$ZIP_Folder/*" -DestinationPath "$ZipName" -Force
+}
+else{
+    $ZipName = "Aki-Server-linux-with-SITCoop.tar.gz"
+    Set-Location "$ZIP_Folder"
+    tar --overwrite -cz -f "../$ZipName" ./*
+}
+
+Write-Output "Built file: $ZipName"
+Write-Output "ZIP_NAME=$ZipName" >> "$env:GITHUB_OUTPUT"


### PR DESCRIPTION
Some background:
I pull-requested the fix to the linux server mod loading issue to the aki team back in the 3.6.x days. [related prs](https://dev.sp-tarkov.com/SPT-AKI/Server/pulls?type=all&state=closed&labels=&milestone=0&assignee=0&poster=0&q=linux)
I have also contributed the Linux server hosting guide to the wiki ([here](https://github.com/stayintarkov/StayInTarkov.Client/wiki/Run-Server-on-Linux-English))

I saw there were commits about building the server on linux (but did not work) and the pr to package aki server with releases.
Hence this pr.

The build script is a modified version of my aki server build script to include the coop mod in the package. 

I left the aki server metadata parsing code as comments in the script in case we want to use them in the future.


> [!IMPORTANT] 
> On Linux, the aki server binary is also called `Aki.Server.exe` because the file name is hardcoded in Aki's code base. When building on Linux, this file is NOT a Windows executable.