### PR TITLE
Fix flea market message lost

### DIFF
--- a/src/CoopConfig.ts
+++ b/src/CoopConfig.ts
@@ -5,6 +5,8 @@ export class CoopConfig {
     public webSocketPort: number;
     public natHelperPort: number;
     public useUPNP: boolean;
+    public useMessageWSUrlOverride: boolean;
+    public messageWSUrlOverride: string;
 
     public static Instance: CoopConfig;
 
@@ -12,6 +14,8 @@ export class CoopConfig {
         this.webSocketPort = 6970;
         this.natHelperPort = 6971;
         this.useUPNP = true;
+        this.useMessageWSUrlOverride = false;
+        this.messageWSUrlOverride = '127.0.0.1:6969';
 
         const configFilePath = path.join(__dirname, "..", "config");
         if(!fs.existsSync(configFilePath))

--- a/src/Overrides/HttpServerHelperOverride.ts
+++ b/src/Overrides/HttpServerHelperOverride.ts
@@ -20,7 +20,7 @@ export class HttpServerHelperOverride {
         const originalUrl = this.httpServerHelper.buildUrl();
         console.log(`Original Message WS Url is ${originalUrl}`);
         if (CoopConfig.Instance.useMessageWSUrlOverride) {
-            console.log(`Override Message WS Url to ${originalUrl}`);
+            console.log(`Override Message WS Url to ${CoopConfig.Instance.messageWSUrlOverride}`);
             return `ws://${CoopConfig.Instance.messageWSUrlOverride}`;
         } else {
             return `ws://${originalUrl}`;

--- a/src/Overrides/HttpServerHelperOverride.ts
+++ b/src/Overrides/HttpServerHelperOverride.ts
@@ -1,0 +1,42 @@
+import { DependencyContainer } from "tsyringe";
+import { CoopConfig } from "./../CoopConfig";
+import { HttpServerHelper } from "@spt-aki/helpers/HttpServerHelper";
+
+export class HttpServerHelperOverride {
+    container: DependencyContainer;
+
+    httpServerHelper: HttpServerHelper;
+    
+    constructor
+    (
+        container: DependencyContainer
+    )
+    {
+        this.container = container;
+        this.httpServerHelper = container.resolve<HttpServerHelper>("HttpServerHelper");
+    }
+
+    public getWebsocketUrl(): string {
+        const originalUrl = this.httpServerHelper.buildUrl();
+        console.log(`Original Message WS Url is ${originalUrl}`);
+        if (CoopConfig.Instance.useMessageWSUrlOverride) {
+            console.log(`Override Message WS Url to ${originalUrl}`);
+            return `ws://${CoopConfig.Instance.messageWSUrlOverride}`;
+        } else {
+            return `ws://${originalUrl}`;
+        }
+    }
+
+    public override(): void 
+    {
+        this.container.afterResolution("HttpServerHelper", (_t, result: HttpServerHelper) => 
+        {
+            // We want to replace the original method logic with something different
+            result.getWebsocketUrl = () => 
+            {
+                return this.getWebsocketUrl();
+            }
+            // The modifier Always makes sure this replacement method is ALWAYS replaced
+        }, {frequency: "Always"});
+    }
+}

--- a/src/StayInTarkovMod.ts
+++ b/src/StayInTarkovMod.ts
@@ -33,6 +33,7 @@ import { friendlyAI } from "./FriendlyAI";
 import { BundleLoaderOverride } from "./Overrides/BundleLoaderOverride";
 import { LauncherControllerOverride } from "./Overrides/LauncherControllerOverride";
 import { GameControllerOverride } from "./Overrides/GameControllerOverride";
+import { HttpServerHelperOverride } from "./Overrides/HttpServerHelperOverride";
 // -------------------------------------------------------------------------
 
 // Controllers -------------------------------------------------------------
@@ -150,6 +151,10 @@ export class StayInTarkovMod implements IPreAkiLoadMod, IPostDBLoadMod
         // ----------------------- Launcher Controller overrides -------------------------------------------------
         const launcherControllerOverride = new LauncherControllerOverride(container, gameControllerOverride);
         launcherControllerOverride.override();
+
+        // ----------------------- Http Server Helper overrides ------------------------------------------------
+        const httpServerHelperOverride = new HttpServerHelperOverride(container);
+        httpServerHelperOverride.override();
 
         // Connect to this module
         staticRouterModService.registerStaticRouter(


### PR DESCRIPTION
This is a temp fix for flea message websocket connection(Especially when running on a VPS), maybe one day can find a best way.

If you can't received flea market sold items messages or any other messages, change useMessageWSUrlOverride to true and set messageWSUrlOverride with your ip:port in CoopConfig.json.
Then restart server, if you see [WS] Player : YOURID (SESSIONID) has connected when you connect to server, that means everything is working fine