### PR TITLE
SPT Launcher support: Add option to check password on login and fix overrides

### DIFF
--- a/src/CoopConfig.ts
+++ b/src/CoopConfig.ts
@@ -7,6 +7,7 @@ export class CoopConfig {
     public useUPNP: boolean;
     public useMessageWSUrlOverride: boolean;
     public messageWSUrlOverride: string;
+    public checkPasswordOnLogin: boolean;
 
     public static Instance: CoopConfig;
 
@@ -16,6 +17,7 @@ export class CoopConfig {
         this.useUPNP = true;
         this.useMessageWSUrlOverride = false;
         this.messageWSUrlOverride = '127.0.0.1:6969';
+        this.checkPasswordOnLogin = false;
 
         const configFilePath = path.join(__dirname, "..", "config");
         if(!fs.existsSync(configFilePath))

--- a/src/CoopConfig.ts
+++ b/src/CoopConfig.ts
@@ -7,6 +7,9 @@ export class CoopConfig {
     public useUPNP: boolean;
     public useMessageWSUrlOverride: boolean;
     public messageWSUrlOverride: string;
+    /**
+     * Forces players to use a password. FALSE IF USING SPT LAUNCHER!
+     */
     public checkPasswordOnLogin: boolean;
 
     public static Instance: CoopConfig;
@@ -17,7 +20,10 @@ export class CoopConfig {
         this.useUPNP = true;
         this.useMessageWSUrlOverride = false;
         this.messageWSUrlOverride = '127.0.0.1:6969';
-        this.checkPasswordOnLogin = false;
+
+        // This is up for debate. This forces players to use a password..
+        // However, this breaks the SPT Launcher if a user wanted to use that
+        this.checkPasswordOnLogin = true;
 
         const configFilePath = path.join(__dirname, "..", "config");
         if(!fs.existsSync(configFilePath))

--- a/src/Overrides/GameControllerOverride.ts
+++ b/src/Overrides/GameControllerOverride.ts
@@ -3,6 +3,7 @@ import { GameController } from "@spt-aki/controllers/GameController";
 import { IGameConfigResponse } from "@spt-aki/models/eft/game/IGameConfigResponse";
 import { ProfileHelper } from "@spt-aki/helpers/ProfileHelper";
 import { DatabaseServer } from "@spt-aki/servers/DatabaseServer";
+import { HttpServerHelper } from "@spt-aki/helpers/HttpServerHelper";
 
 export class GameControllerOverride
 {
@@ -12,6 +13,7 @@ export class GameControllerOverride
     databaseServer: DatabaseServer;
     
     protected sessionBackendUrl: Record<string, string> = {};
+    httpServerHelper: HttpServerHelper;
     
     constructor
     (
@@ -21,6 +23,7 @@ export class GameControllerOverride
         this.container = container;
         this.profileHelper = container.resolve<ProfileHelper>("ProfileHelper");
         this.databaseServer = container.resolve<DatabaseServer>("DatabaseServer");
+        this.httpServerHelper = container.resolve<HttpServerHelper>("HttpServerHelper");
     }
 
     public setSessionBackendUrl(sessionID: string, backendUrl: string)
@@ -31,6 +34,10 @@ export class GameControllerOverride
     private getGameConfig(sessionID: string, backendUrl: string): IGameConfigResponse
     {
         const profile = this.profileHelper.getPmcProfile(sessionID);
+
+        if (backendUrl === undefined || backendUrl === "") {
+            backendUrl =  this.httpServerHelper.getBackendUrl();
+        }
 
         const config: IGameConfigResponse = {
             languages: this.databaseServer.getTables().locales.languages,

--- a/src/Overrides/LauncherControllerOverride.ts
+++ b/src/Overrides/LauncherControllerOverride.ts
@@ -11,16 +11,19 @@ export class LauncherControllerOverride
     container: DependencyContainer;
     saveServer: SaveServer;
     gameControllerOverride: GameControllerOverride;
+    coopConfig: CoopConfig;
     
     constructor
     (
         container: DependencyContainer,
         gameControllerOverride: GameControllerOverride,
+        coopConfig: CoopConfig
     )
     {
         this.container = container;
         this.saveServer = container.resolve<SaveServer>("SaveServer");
         this.gameControllerOverride = gameControllerOverride;
+        this.coopConfig = coopConfig;
     }
 
     private login(info: any)
@@ -31,19 +34,22 @@ export class LauncherControllerOverride
         {
             const account = this.saveServer.getProfile(sessionID).info;
             
+            // does the account exist?
             if (info.username === account.username)
             {
-                if(info.password === account.password)
-                {
-                    if(info.backendUrl !== undefined && info.backendUrl !== "")
-                    {
+                // should we check password? if yes, check it
+                if (!this.coopConfig.checkPasswordOnLogin || info.password === account.password) {
+
+                    if(info.backendUrl !== undefined && info.backendUrl !== "") {
                         this.gameControllerOverride.setSessionBackendUrl(sessionID, info.backendUrl);
                     
                         return sessionID;
                     }
+                    else {
+                        return sessionID;
+                    }
                 }
-                else
-                {
+                else {
                     return "INVALID_PASSWORD";
                 }
             }

--- a/src/SITConfig.ts
+++ b/src/SITConfig.ts
@@ -52,7 +52,7 @@ export class SITConfig {
             [
                 {
                     url: "/SIT/Config",
-                    action: (url, info: any, sessionId, output) => {
+                    action: (url: string, info: any, sessionID: string, output: string): any => {
                         console.log(SITConfig.Instance)
                         output = JSON.stringify(SITConfig.Instance);
                         return output;

--- a/src/StayInTarkovMod.ts
+++ b/src/StayInTarkovMod.ts
@@ -145,7 +145,7 @@ export class StayInTarkovMod implements IPreAkiLoadMod, IPostDBLoadMod
         gameControllerOverride.override();
 
         // ----------------------- Launcher Controller overrides -------------------------------------------------
-        const launcherControllerOverride = new LauncherControllerOverride(container, gameControllerOverride);
+        const launcherControllerOverride = new LauncherControllerOverride(container, gameControllerOverride, this.coopConfig);
         launcherControllerOverride.override();
 
         // ----------------------- Http Server Helper overrides ------------------------------------------------


### PR DESCRIPTION
This PR:
- Adds an option to allow accounts to login without using a password (SPT Launcher requirement)
- Fixes GameControllerOverrides to use default http.json backendUrl setting as a backup if SIT Manager isn't being used and sending the information